### PR TITLE
Remove throw when payload is not an Object

### DIFF
--- a/src/angular-MQTT.js
+++ b/src/angular-MQTT.js
@@ -29,7 +29,7 @@ angular.module('ngMQTT', [])
                 try {
                     var data = JSON.parse(payload.toString());
                 }catch (e){
-                    throw new Error("received data can not parse for JSON !");
+                    var data = payload.toString();
                 }
                 angular.forEach(callbacks,function(callback, name){
                     var regexpStr = name.replace(new RegExp('(#)|(\\*)'),function(str){


### PR DESCRIPTION
According to the MQTT Standar, the payload is not always a json Object or json Array. It could be binary data.
