### PR TITLE
Hash topic subscription

### DIFF
--- a/src/angular-MQTT.js
+++ b/src/angular-MQTT.js
@@ -41,7 +41,7 @@ angular.module('ngMQTT', [])
                     });
                     if(topic.match(regexpStr)){
                         $rootScope.$apply(function() {
-                            callback(data);
+                            callback(data, topic);
                         });
                     }
                 })


### PR DESCRIPTION
What happens if you subscribe to #. You wont be able to detect from what topic is the message. I added the topic as a second parameter on the callback